### PR TITLE
adding accessor for events in clockwork.manager

### DIFF
--- a/lib/clockwork/manager.rb
+++ b/lib/clockwork/manager.rb
@@ -3,6 +3,7 @@ module Clockwork
     class NoHandlerDefined < RuntimeError; end
 
     attr_reader :config
+    attr_accessor :events
 
     def initialize
       @events = []

--- a/lib/clockwork/manager.rb
+++ b/lib/clockwork/manager.rb
@@ -2,8 +2,7 @@ module Clockwork
   class Manager
     class NoHandlerDefined < RuntimeError; end
 
-    attr_reader :config
-    attr_accessor :events
+    attr_reader :config, :events
 
     def initialize
       @events = []


### PR DESCRIPTION
1. Adding `attr_accessor` for events in `manager.rb` to gather all of the jobs as defined in `clock.rb`